### PR TITLE
Updated border-width: dotted to border-style: dotted

### DIFF
--- a/css.md
+++ b/css.md
@@ -1091,7 +1091,7 @@ a {
 ```css
 /* All borders set to dotted */
 div {
-  border-width: dotted;
+  border-style: dotted;
 }
 ```
 


### PR DESCRIPTION
In the boder-style section, there is a typo : boder-width, and it should be border-style.