### PR TITLE
Corrected the link of MDN Descendant selectors doc in css.md

### DIFF
--- a/css.md
+++ b/css.md
@@ -457,7 +457,7 @@ a:visited {
 ## Descendant selectors
 * This selector is represented by a single space ( ) character & combines two selectors such that elements matched by the second selector are selected if they have an ancestor element matching the first selector
 * It will apply to any element inside other element without being a direct dependency
-* [MDN Descendant selectors doc]()https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_selectors
+* [MDN Descendant selectors doc](https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_selectors)
 
 **Example:**
 ```css


### PR DESCRIPTION
the link https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_selectors is not in ().