### PR TITLE
The fetch example link returns 404

### DIFF
--- a/browserapi.md
+++ b/browserapi.md
@@ -2084,7 +2084,7 @@ fetch(apiURL)
   });
 ```
 
-* Now we can use everything that we learned on [this fetch example](https://github.com/nisnardi/fetch-demo)
+* Now we can use everything that we learned on [this fetch example](https://github.com/nisnardi/fetch-demo) ??
 
 #### Practice
 [Exercise 52](./exercises/browser/ex_52.md)


### PR DESCRIPTION
The fetch example link doesn't work. Can remove it or update it.